### PR TITLE
Add onFrameDimensionsChanged callback for iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,18 +11,12 @@
 
   const handleFrameDimensionsChanged = (data: { width: number; height: number; rotation: number }) => {
     if (data.width > 0 && data.height > 0) {
-      // Scale to fit within max dimensions while maintaining aspect ratio
-      const maxSize = 200;
-      const aspectRatio = data.width / data.height;
-      const scaledWidth = aspectRatio > 1 ? maxSize : maxSize * aspectRatio;
-      const scaledHeight = aspectRatio > 1 ? maxSize / aspectRatio : maxSize;
-      setDimensions({ width: scaledWidth, height: scaledHeight });
+      setDimensions({ width: data.width, height: data.height });
     }
   };
 
   <TwilioVideoParticipantView
     style={{ width: dimensions.width, height: dimensions.height }}
-    scaleType="fit"
     trackIdentifier={trackIdentifier}
     onFrameDimensionsChanged={handleFrameDimensionsChanged}
   />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   <TwilioVideoParticipantView
     style={{ width: dimensions.width, height: dimensions.height }}
     trackIdentifier={trackIdentifier}
+    key={trackSid}
     onFrameDimensionsChanged={handleFrameDimensionsChanged}
   />
   ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ### Changes
 
+- Added `onFrameDimensionsChanged` callback to `TwilioVideoParticipantView` on iOS, providing parity with Android. This callback is fired when the remote video frame dimensions change, returning `{width, height, rotation}`. This enables dynamic video view sizing based on the actual video dimensions.
+
+  **Example usage:**
+
+  ```tsx
+  const [dimensions, setDimensions] = useState({ width: 100, height: 100 });
+
+  const handleFrameDimensionsChanged = (data: { width: number; height: number; rotation: number }) => {
+    if (data.width > 0 && data.height > 0) {
+      // Scale to fit within max dimensions while maintaining aspect ratio
+      const maxSize = 200;
+      const aspectRatio = data.width / data.height;
+      const scaledWidth = aspectRatio > 1 ? maxSize : maxSize * aspectRatio;
+      const scaledHeight = aspectRatio > 1 ? maxSize / aspectRatio : maxSize;
+      setDimensions({ width: scaledWidth, height: scaledHeight });
+    }
+  };
+
+  <TwilioVideoParticipantView
+    style={{ width: dimensions.width, height: dimensions.height }}
+    scaleType="fit"
+    trackIdentifier={trackIdentifier}
+    onFrameDimensionsChanged={handleFrameDimensionsChanged}
+  />
+  ```
 - Added `videoFormat` option to `connect()` method on both iOS and Android platforms. This allows users to specify the maximum video capture format (width, height, and frame rate) when connecting to a room. When `videoFormat` is not provided, the SDK automatically selects the best available format from the camera, or fallbacks to 1280x720, 30 FPS video if the camera video format cannot be determined. Note: On Android, frame rates lower than 15 fps will have no effect.
 
   > **Please note:** with this change, the SDK will no longer set the following default resolutions:

--- a/ExampleApp/ios/ExampleApp.xcodeproj/project.pbxproj
+++ b/ExampleApp/ios/ExampleApp.xcodeproj/project.pbxproj
@@ -9,9 +9,9 @@
 /* Begin PBXBuildFile section */
 		0BD94E4B1D6A3055BCB1BAAF /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
-		4D29F1A2BCD4FCAE45C81AD1 /* libPods-ExampleApp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 661C9B269B75E78B04127490 /* libPods-ExampleApp.a */; };
 		761780ED2CA45674006654EE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761780EC2CA45674006654EE /* AppDelegate.swift */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
+		AC8D3040AE26C6DAE549AFBD /* libPods-ExampleApp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = ECF0233530D93D5A17FFDA52 /* libPods-ExampleApp.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -19,11 +19,11 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = ExampleApp/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = ExampleApp/Info.plist; sourceTree = "<group>"; };
 		13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = PrivacyInfo.xcprivacy; path = ExampleApp/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
-		661C9B269B75E78B04127490 /* libPods-ExampleApp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ExampleApp.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		761780EC2CA45674006654EE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = ExampleApp/AppDelegate.swift; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = ExampleApp/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		8A6DD6CC00B900BA8EFA46F7 /* Pods-ExampleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleApp.release.xcconfig"; path = "Target Support Files/Pods-ExampleApp/Pods-ExampleApp.release.xcconfig"; sourceTree = "<group>"; };
-		A573853D60ED35A8630EAB88 /* Pods-ExampleApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleApp.debug.xcconfig"; path = "Target Support Files/Pods-ExampleApp/Pods-ExampleApp.debug.xcconfig"; sourceTree = "<group>"; };
+		8802906BBA0D05B060DB95EB /* Pods-ExampleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleApp.release.xcconfig"; path = "Target Support Files/Pods-ExampleApp/Pods-ExampleApp.release.xcconfig"; sourceTree = "<group>"; };
+		EA538CDE5EF35AAC427AD455 /* Pods-ExampleApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleApp.debug.xcconfig"; path = "Target Support Files/Pods-ExampleApp/Pods-ExampleApp.debug.xcconfig"; sourceTree = "<group>"; };
+		ECF0233530D93D5A17FFDA52 /* libPods-ExampleApp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ExampleApp.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -32,7 +32,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4D29F1A2BCD4FCAE45C81AD1 /* libPods-ExampleApp.a in Frameworks */,
+				AC8D3040AE26C6DAE549AFBD /* libPods-ExampleApp.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -55,7 +55,7 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				661C9B269B75E78B04127490 /* libPods-ExampleApp.a */,
+				ECF0233530D93D5A17FFDA52 /* libPods-ExampleApp.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -92,8 +92,8 @@
 		BBD78D7AC51CEA395F1C20DB /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				A573853D60ED35A8630EAB88 /* Pods-ExampleApp.debug.xcconfig */,
-				8A6DD6CC00B900BA8EFA46F7 /* Pods-ExampleApp.release.xcconfig */,
+				EA538CDE5EF35AAC427AD455 /* Pods-ExampleApp.debug.xcconfig */,
+				8802906BBA0D05B060DB95EB /* Pods-ExampleApp.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -105,13 +105,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "ExampleApp" */;
 			buildPhases = (
-				52D8F9950A732306DA093430 /* [CP] Check Pods Manifest.lock */,
+				DA7EF94F269848441BFAB506 /* [CP] Check Pods Manifest.lock */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				C2EFEE15E823814022A44F0C /* [CP] Embed Pods Frameworks */,
-				AF494D64EAF8CADED50E2354 /* [CP] Copy Pods Resources */,
+				27AAE1C7C4DE13A5A801A91B /* [CP] Embed Pods Frameworks */,
+				8A1C2F113F30F30A05012409 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -183,7 +183,41 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
 		};
-		52D8F9950A732306DA093430 /* [CP] Check Pods Manifest.lock */ = {
+		27AAE1C7C4DE13A5A801A91B /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ExampleApp/Pods-ExampleApp-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ExampleApp/Pods-ExampleApp-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ExampleApp/Pods-ExampleApp-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		8A1C2F113F30F30A05012409 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ExampleApp/Pods-ExampleApp-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ExampleApp/Pods-ExampleApp-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ExampleApp/Pods-ExampleApp-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		DA7EF94F269848441BFAB506 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -205,40 +239,6 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		AF494D64EAF8CADED50E2354 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ExampleApp/Pods-ExampleApp-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ExampleApp/Pods-ExampleApp-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ExampleApp/Pods-ExampleApp-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		C2EFEE15E823814022A44F0C /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ExampleApp/Pods-ExampleApp-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ExampleApp/Pods-ExampleApp-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ExampleApp/Pods-ExampleApp-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -255,7 +255,7 @@
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A573853D60ED35A8630EAB88 /* Pods-ExampleApp.debug.xcconfig */;
+			baseConfigurationReference = EA538CDE5EF35AAC427AD455 /* Pods-ExampleApp.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -364,7 +364,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8A6DD6CC00B900BA8EFA46F7 /* Pods-ExampleApp.release.xcconfig */;
+			baseConfigurationReference = 8802906BBA0D05B060DB95EB /* Pods-ExampleApp.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;

--- a/ExampleApp/src/App.tsx
+++ b/ExampleApp/src/App.tsx
@@ -658,6 +658,7 @@ const Example = () => {
                                 {Array.from(videoTracks, ([trackSid, trackIdentifier]) => {
                                     return (
                                         <TwilioVideoParticipantView
+                                            scaleType="fit"
                                             style={styles.remoteVideo}
                                             key={trackSid}
                                             trackIdentifier={trackIdentifier as any}

--- a/docs/README.md
+++ b/docs/README.md
@@ -237,6 +237,12 @@
 | trackIdentifier | shape({participantSid: string, videoTrackSid: string}) | The participant sid and video track sid you want to render in the view |
 | scaleType       | enum('fit','fill')                                     | How the video stream should be scaled to fit its container             |
 
+#### Callbacks
+
+| Property                 | Parameters                                          | Description                                 |
+| :----------------------- | :-------------------------------------------------- | :------------------------------------------ |
+| onFrameDimensionsChanged | `{height: number, width: number, rotation: number}` | Callback when video frame dimensions change |
+
 ---
 
 ### TwilioVideoScreenShareView ([src/TwilioVideoScreenShareView.android.js](../src/TwilioVideoScreenShareView.android.js))

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,15 +23,28 @@ declare module "@twilio/video-react-native-sdk" {
         frameRate: number;
     }
 
+    interface FrameDimensionsData {
+        /** Video frame height */
+        height: number;
+        /** Video frame width */
+        width: number;
+        /** Video frame rotation */
+        rotation: number;
+    }
+
     interface TwilioVideoParticipantViewProps extends ViewProps {
         trackIdentifier: TrackIdentifier;
         ref?: React.Ref<any>;
         scaleType?: scaleType;
         /**
- * Whether to apply Z ordering to this view.  Setting this to true will cause
- * this view to appear above other Twilio Video views.
- */
+         * Whether to apply Z ordering to this view.  Setting this to true will cause
+         * this view to appear above other Twilio Video views.
+         */
         applyZOrder?: boolean|undefined;
+        /**
+         * Callback when video frame dimensions change.
+         */
+        onFrameDimensionsChanged?: (data: FrameDimensionsData) => void;
     }
 
     interface TwilioVideoLocalViewProps extends ViewProps {

--- a/ios/RCTTWRemoteVideoView.h
+++ b/ios/RCTTWRemoteVideoView.h
@@ -1,0 +1,31 @@
+//
+//  RCTTWRemoteVideoView.h
+//  RNTwilioVideoWebRTC
+//
+//  Custom container view for remote participant video that implements
+//  TVIVideoViewDelegate to receive frame dimension change callbacks.
+//
+
+#import <UIKit/UIKit.h>
+#import <React/RCTComponent.h>
+#import <TwilioVideo/TwilioVideo.h>
+
+@interface RCTTWRemoteVideoView : UIView <TVIVideoViewDelegate>
+
+/**
+ * The inner TVIVideoView that renders the video.
+ */
+@property (nonatomic, strong, readonly) TVIVideoView *videoView;
+
+/**
+ * Callback when video frame dimensions change.
+ */
+@property (nonatomic, copy) RCTDirectEventBlock onFrameDimensionsChanged;
+
+/**
+ * Current video orientation (used for rotation calculation).
+ */
+@property (nonatomic, assign) TVIVideoOrientation currentOrientation;
+
+@end
+

--- a/ios/RCTTWRemoteVideoView.m
+++ b/ios/RCTTWRemoteVideoView.m
@@ -1,0 +1,103 @@
+//
+//  RCTTWRemoteVideoView.m
+//  RNTwilioVideoWebRTC
+//
+//  Custom container view for remote participant video that implements
+//  TVIVideoViewDelegate to receive frame dimension change callbacks.
+//
+
+#import "RCTTWRemoteVideoView.h"
+
+@interface RCTTWRemoteVideoView ()
+
+@property (nonatomic, strong, readwrite) TVIVideoView *videoView;
+
+@end
+
+@implementation RCTTWRemoteVideoView
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+    if (self) {
+        [self setupVideoView];
+    }
+    return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)coder {
+    self = [super initWithCoder:coder];
+    if (self) {
+        [self setupVideoView];
+    }
+    return self;
+}
+
+- (void)setupVideoView {
+    _currentOrientation = TVIVideoOrientationUp;
+    _videoView = [[TVIVideoView alloc] initWithFrame:self.bounds delegate:self];
+    _videoView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    [self addSubview:_videoView];
+}
+
+#pragma mark - TVIVideoViewDelegate
+
+- (void)videoViewDidReceiveData:(TVIVideoView *)view {
+    // Fire the callback with initial dimensions when first frame is received
+    // This is needed because videoDimensionsDidChange only fires when dimensions CHANGE,
+    // not when they are first set
+    if (self.onFrameDimensionsChanged) {
+        CMVideoDimensions dimensions = view.videoDimensions;
+        NSInteger rotation = [self rotationDegreesFromOrientation:self.currentOrientation];
+        self.onFrameDimensionsChanged(@{
+            @"width": @(dimensions.width),
+            @"height": @(dimensions.height),
+            @"rotation": @(rotation)
+        });
+    }
+}
+
+- (void)videoView:(TVIVideoView *)view videoDimensionsDidChange:(CMVideoDimensions)dimensions {
+    if (self.onFrameDimensionsChanged) {
+        NSInteger rotation = [self rotationDegreesFromOrientation:self.currentOrientation];
+        self.onFrameDimensionsChanged(@{
+            @"width": @(dimensions.width),
+            @"height": @(dimensions.height),
+            @"rotation": @(rotation)
+        });
+    }
+}
+
+- (void)videoView:(TVIVideoView *)view videoOrientationDidChange:(TVIVideoOrientation)orientation {
+    self.currentOrientation = orientation;
+    
+    // Also fire the callback when orientation changes with current dimensions
+    if (self.onFrameDimensionsChanged) {
+        CMVideoDimensions dimensions = view.videoDimensions;
+        NSInteger rotation = [self rotationDegreesFromOrientation:orientation];
+        self.onFrameDimensionsChanged(@{
+            @"width": @(dimensions.width),
+            @"height": @(dimensions.height),
+            @"rotation": @(rotation)
+        });
+    }
+}
+
+#pragma mark - Rotation Mapping
+
+- (NSInteger)rotationDegreesFromOrientation:(TVIVideoOrientation)orientation {
+    switch (orientation) {
+        case TVIVideoOrientationUp:
+            return 0;
+        case TVIVideoOrientationLeft:
+            return 90;
+        case TVIVideoOrientationDown:
+            return 180;
+        case TVIVideoOrientationRight:
+            return 270;
+        default:
+            return 0;
+    }
+}
+
+@end
+

--- a/ios/RCTTWRemoteVideoViewManager.m
+++ b/ios/RCTTWRemoteVideoViewManager.m
@@ -10,6 +10,7 @@
 
 #import <React/RCTConvert.h>
 #import "RCTTWVideoModule.h"
+#import "RCTTWRemoteVideoView.h"
 
 @interface RCTTWVideoTrackIdentifier : NSObject
 
@@ -47,26 +48,22 @@
 
 RCT_EXPORT_MODULE()
 
-RCT_CUSTOM_VIEW_PROPERTY(scalesType, NSInteger, TVIVideoView) {
-  view.subviews[0].contentMode = [RCTConvert NSInteger:json];
-}
-
 - (UIView *)view {
-  UIView *container = [[UIView alloc] init];
-  TVIVideoView *inner = [[TVIVideoView alloc] init];
-  inner.autoresizingMask = (UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth);
-  [container addSubview:inner];
-  return container;
+  return [[RCTTWRemoteVideoView alloc] init];
 }
 
-RCT_CUSTOM_VIEW_PROPERTY(trackIdentifier, RCTTWVideoTrackIdentifier, TVIVideoView) {
+RCT_EXPORT_VIEW_PROPERTY(onFrameDimensionsChanged, RCTDirectEventBlock)
+
+RCT_CUSTOM_VIEW_PROPERTY(scalesType, NSInteger, RCTTWRemoteVideoView) {
+  view.videoView.contentMode = [RCTConvert NSInteger:json];
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(trackIdentifier, RCTTWVideoTrackIdentifier, RCTTWRemoteVideoView) {
   if (json) {
     RCTTWVideoModule *videoModule = [self.bridge moduleForName:@"TWVideoModule"];
     RCTTWVideoTrackIdentifier *id = [RCTConvert RCTTWVideoTrackIdentifier:json];
-
-    [videoModule addParticipantView:view.subviews[0] sid:id.participantSid trackSid:id.videoTrackSid];
+    [videoModule addParticipantView:view.videoView sid:id.participantSid trackSid:id.videoTrackSid];
   }
 }
-
 
 @end

--- a/ios/RNTwilioVideoWebRTC.xcodeproj/project.pbxproj
+++ b/ios/RNTwilioVideoWebRTC.xcodeproj/project.pbxproj
@@ -11,10 +11,12 @@
 		73814A35203776CD00E8C67D /* RCTTWRemoteVideoViewManager.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 738F9D6A203760FF00058972 /* RCTTWRemoteVideoViewManager.h */; };
 		73814A36203776CD00E8C67D /* RCTTWSerializable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 738F9D65203760FF00058972 /* RCTTWSerializable.h */; };
 		73814A37203776CD00E8C67D /* RCTTWVideoModule.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 738F9D63203760FF00058972 /* RCTTWVideoModule.h */; };
+		73814A38203776CD00E8C67D /* RCTTWRemoteVideoView.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 738F9D70203760FF00058972 /* RCTTWRemoteVideoView.h */; };
 		738F9D6B203760FF00058972 /* RCTTWSerializable.m in Sources */ = {isa = PBXBuildFile; fileRef = 738F9D64203760FF00058972 /* RCTTWSerializable.m */; };
 		738F9D6C203760FF00058972 /* RCTTWRemoteVideoViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 738F9D66203760FF00058972 /* RCTTWRemoteVideoViewManager.m */; };
 		738F9D6D203760FF00058972 /* RCTTWLocalVideoViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 738F9D67203760FF00058972 /* RCTTWLocalVideoViewManager.m */; };
 		738F9D6E203760FF00058972 /* RCTTWVideoModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 738F9D68203760FF00058972 /* RCTTWVideoModule.m */; };
+		738F9D6F203760FF00058972 /* RCTTWRemoteVideoView.m in Sources */ = {isa = PBXBuildFile; fileRef = 738F9D71203760FF00058972 /* RCTTWRemoteVideoView.m */; };
 		73AC89CA20377EA700038475 /* TwilioVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73AC89C920377EA700038475 /* TwilioVideo.framework */; };
 /* End PBXBuildFile section */
 
@@ -27,6 +29,7 @@
 			files = (
 				73814A34203776CD00E8C67D /* RCTTWLocalVideoViewManager.h in CopyFiles */,
 				73814A35203776CD00E8C67D /* RCTTWRemoteVideoViewManager.h in CopyFiles */,
+				73814A38203776CD00E8C67D /* RCTTWRemoteVideoView.h in CopyFiles */,
 				73814A36203776CD00E8C67D /* RCTTWSerializable.h in CopyFiles */,
 				73814A37203776CD00E8C67D /* RCTTWVideoModule.h in CopyFiles */,
 			);
@@ -44,6 +47,8 @@
 		738F9D68203760FF00058972 /* RCTTWVideoModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTTWVideoModule.m; sourceTree = SOURCE_ROOT; };
 		738F9D69203760FF00058972 /* RCTTWLocalVideoViewManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTTWLocalVideoViewManager.h; sourceTree = SOURCE_ROOT; };
 		738F9D6A203760FF00058972 /* RCTTWRemoteVideoViewManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTTWRemoteVideoViewManager.h; sourceTree = SOURCE_ROOT; };
+		738F9D70203760FF00058972 /* RCTTWRemoteVideoView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTTWRemoteVideoView.h; sourceTree = SOURCE_ROOT; };
+		738F9D71203760FF00058972 /* RCTTWRemoteVideoView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTTWRemoteVideoView.m; sourceTree = SOURCE_ROOT; };
 		73AC89C920377EA700038475 /* TwilioVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = TwilioVideo.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -83,6 +88,8 @@
 				738F9D67203760FF00058972 /* RCTTWLocalVideoViewManager.m */,
 				738F9D6A203760FF00058972 /* RCTTWRemoteVideoViewManager.h */,
 				738F9D66203760FF00058972 /* RCTTWRemoteVideoViewManager.m */,
+				738F9D70203760FF00058972 /* RCTTWRemoteVideoView.h */,
+				738F9D71203760FF00058972 /* RCTTWRemoteVideoView.m */,
 				738F9D65203760FF00058972 /* RCTTWSerializable.h */,
 				738F9D64203760FF00058972 /* RCTTWSerializable.m */,
 				738F9D63203760FF00058972 /* RCTTWVideoModule.h */,
@@ -158,6 +165,7 @@
 			files = (
 				738F9D6E203760FF00058972 /* RCTTWVideoModule.m in Sources */,
 				738F9D6C203760FF00058972 /* RCTTWRemoteVideoViewManager.m in Sources */,
+				738F9D6F203760FF00058972 /* RCTTWRemoteVideoView.m in Sources */,
 				738F9D6B203760FF00058972 /* RCTTWSerializable.m in Sources */,
 				738F9D6D203760FF00058972 /* RCTTWLocalVideoViewManager.m in Sources */,
 			);

--- a/src/TwilioVideoParticipantView.ios.js
+++ b/src/TwilioVideoParticipantView.ios.js
@@ -10,6 +10,14 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { requireNativeComponent, View } from "react-native";
 
+/**
+ * Frame dimensions change callback data structure
+ * @typedef {Object} FrameDimensionsData
+ * @property {number} height - Video frame height
+ * @property {number} width - Video frame width
+ * @property {number} rotation - Video frame rotation
+ */
+
 class TwilioVideoParticipantView extends Component {
   static propTypes = {
     ...View.propTypes,
@@ -23,13 +31,38 @@ class TwilioVideoParticipantView extends Component {
        */
       videoTrackSid: PropTypes.string.isRequired,
     }),
-    scaleType: PropTypes.string,
+    /**
+     * How the video stream should be scaled to fit its container.
+     */
+    scaleType: PropTypes.oneOf(["fit", "fill"]),
+    /**
+     * Callback when video frame dimensions change
+     *
+     * @param {FrameDimensionsData} data - Frame dimensions data
+     */
+    onFrameDimensionsChanged: PropTypes.func,
   };
+
+  buildNativeEventWrappers() {
+    return ["onFrameDimensionsChanged"].reduce((wrappedEvents, eventName) => {
+      if (this.props[eventName]) {
+        return {
+          ...wrappedEvents,
+          [eventName]: (data) => this.props[eventName](data.nativeEvent),
+        };
+      }
+      return wrappedEvents;
+    }, {});
+  }
 
   render() {
     const scalesType = this.props.scaleType === "fit" ? 1 : 2;
     return (
-      <RCTTWRemoteVideoView scalesType={scalesType} {...this.props}>
+      <RCTTWRemoteVideoView
+        scalesType={scalesType}
+        {...this.props}
+        {...this.buildNativeEventWrappers()}
+      >
         {this.props.children}
       </RCTTWRemoteVideoView>
     );


### PR DESCRIPTION
**Changes**
- Added `onFrameDimensionsChanged` callback to `TwilioVideoParticipantView` on iOS, providing parity with Android. This callback is fired when the remote video frame dimensions change, returning `{width, height, rotation}`. This enables dynamic video view sizing based on the actual video dimensions.

  **Example usage:**

  ```tsx
  const [dimensions, setDimensions] = useState({ width: 100, height: 100 });

  const handleFrameDimensionsChanged = (data: { width: number; height: number; rotation: number }) => {
    if (data.width > 0 && data.height > 0) {
      setDimensions({ width: data.width, height: data.height });
    }
  };

  <TwilioVideoParticipantView
    style={{ width: dimensions.width, height: dimensions.height }}
    trackIdentifier={trackIdentifier}
    onFrameDimensionsChanged={handleFrameDimensionsChanged}
  />
  ```

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
