### PR TITLE
Allow flexible React Native peer dependency ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,8 +68,8 @@
   "peerDependencies": {
     "expo": ">=47.0.0",
     "expo-build-properties": ">=0.5.1",
-    "react": "^19.1.0",
-    "react-native": "^0.81.0"
+    "react": ">=19.1.0",
+    "react-native": ">=0.81.0"
   },
   "peerDependenciesMeta": {
     "expo": {


### PR DESCRIPTION
Relax the `react` and `react-native` peer dependency requirements to allow versions greater than or equal to the current minimum supported versions.

React Native 0.85 has been released, and the previous peer dependency range kept this library pinned several generations behind. Using `>=` makes the package more graceful for clients on newer React Native versions while still preserving the minimum supported baseline.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
